### PR TITLE
Include CMakeDependentOption in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(GNUInstallDirs)
+include(CMakeDependentOption)
 
 # Options.
 find_package(Libsystemd)


### PR DESCRIPTION
cmake complains about unknown command cmake_dependent_option when building stubby separate from getdns